### PR TITLE
Remove support for local development.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,6 @@ let checksum = "93d86da0d1ca36a11dc8393f50bdc6c12def6c669b6c6bb2ae482641ffc052e3
 let version = "v1.0.22-alpha"
 let url = "https://github.com/matrix-org/matrix-rust-components-swift/releases/download/\(version)/MatrixSDKFFI.xcframework.zip"
 
-let useLocalBinary = false
-let binaryTarget: Target = useLocalBinary ? .binaryTarget(name: "MatrixSDKFFI", path: "MatrixSDKFFI.xcframework")
-                                          : .binaryTarget(name: "MatrixSDKFFI", url: url, checksum: checksum)
-
 let package = Package(
     name: "MatrixRustSDK",
     platforms: [
@@ -18,25 +14,10 @@ let package = Package(
         .macOS(.v12)
     ],
     products: [
-        .library(
-            name: "MatrixRustSDK",
-            targets: ["MatrixRustSDK"]),
+        .library(name: "MatrixRustSDK", targets: ["MatrixRustSDK"]),
     ],
     targets: [
-        binaryTarget,
-        /*
-         * A placeholder wrapper for our binaryTarget so that Xcode will ensure this is
-         * downloaded/built before trying to use it in the build process
-         * A bit hacky but necessary for now https://github.com/mozilla/application-services/issues/4422
-         */
-        .target(
-            name: "MatrixRustSDK",
-            dependencies: [
-                .target(name: "MatrixSDKFFI")
-            ]
-        ),
-        .testTarget(
-            name: "MatrixRustSDKTests",
-            dependencies: ["MatrixRustSDK"]),
+        .binaryTarget(name: "MatrixSDKFFI", url: url, checksum: checksum),
+        .target(name: "MatrixRustSDK", dependencies: [.target(name: "MatrixSDKFFI")])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -5,30 +5,8 @@ This repository is a Swift Package for distributing releases of the [Matrix Rust
 ## Releasing
 
 Whenever a new release of the underlying components is available, we need to tag a new release in this repo to make them available to Swift components. 
-To do so we need to:
-* running the `.xcframework` build script from `matrix-rust-sdk/apple`
-* copy the generated `.swift` files to this repository under `Sources/MatrixRustComponentsSwift`
-* update the tag version and checksum inside `Package.swift`
-* create a new tag and upload the zipped version of the `.xcframework` to it's artefacts section
+This is done with the [release script](Tools/Scripts/README.md) found in the Tools directory. 
 
 ## Testing locally
 
-The package can be added to an Xcode project from a local checkout and the binary target can be configured by toggling the `useLocalBinary` boolean. It might be necessary to manually add the resulting library to your project's `General/Frameworks, Libraries, and Embedded Content` for it to work.
-
-## Requirements
-
-To build the package you will need the following installed:
-1. cargo + rustup https://www.rust-lang.org/tools/install
-2. uniffi-bindgen `cargo install uniffi_bindgen --version x.x.x | --git https://github.com/mozilla/uniffi-rs --rev abc...` where the version or revision needs to match the one defined in the rust-sdk-ffi crate [Cargo.toml](https://github.com/matrix-org/matrix-rust-sdk/blob/main/Cargo.toml).
-3. nightly toolchain and simulator targets for your desired platform. See the [release script](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/apple/build_xcframework.sh) for all possible options.
-```
-rustup toolchain install nightly
-rustup default nightly
-rustup target add aarch64-apple-ios --toolchain nightly
-rustup target add aarch64-apple-darwin --toolchain nightly
-rustup target add aarch64-apple-ios-sim --toolchain nightly
-rustup target add x86_64-apple-ios --toolchain nightly
-rustup target add x86_64-apple-darwin --toolchain nightly
-```
-4. matrix-rust-sdk cloned next to this repo `git clone https://github.com/matrix-org/matrix-rust-sdk`
-5. When running the `debug_build_xcframework.sh` script, enable the `useLocalBinary` flag in `Package.swift`.
+As the package vendors a pre-built binary of the SDK, all local development is done via the SDK's repo instead of this one.

--- a/Tests/MatrixRustSDKTests/MatrixRustComponentsSwiftTests.swift
+++ b/Tests/MatrixRustSDKTests/MatrixRustComponentsSwiftTests.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import MatrixRustSDK
-
-final class MatrixRustComponentsSwiftTests: XCTestCase {
-    
-}

--- a/Tools/Scripts/README.md
+++ b/Tools/Scripts/README.md
@@ -9,3 +9,10 @@ python3 release.py --version v1.0.18-alpha
 ```
 
 For help: `release.py -h`
+
+## Requirements
+
+To make the release you will need the following installed:
+1. cargo + rustup https://www.rust-lang.org/tools/install
+2. matrix-rust-sdk cloned next to this repo `git clone https://github.com/matrix-org/matrix-rust-sdk`
+3. Any dependencies required to build the matrix-rust-sdk as mentioned in the [Apple platforms readme](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/apple/README.md).

--- a/Tools/Scripts/release.py
+++ b/Tools/Scripts/release.py
@@ -58,8 +58,6 @@ with FileInput(files=[root + '/Package.swift'], inplace=True) as file:
             line = 'let checksum = "' + checksum + '"'
         if line.startswith('let version ='):
             line = 'let version = "' + version + '"'
-        if line.startswith('let useLocalBinary = true'):
-            line = 'let useLocalBinary = false'
         print(line)
 
 sdk_commit_hash = subprocess.getoutput("cat " + sdk_path + "/.git/refs/heads/main")


### PR DESCRIPTION
- matrix-rust-sdk can now be used for local development via `cargo xtask swift build-framework`.
- Update instructions to point to the release tool and SDK docs. 
- Remove Test target as these live in the matrix-rust-sdk repo.