### PR TITLE
Fix "Getting Started.md"

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -76,7 +76,7 @@ let syncService = try await client.syncService().finish()
 // Listen to room list updates.
 let listener = AllRoomsListener()
 let roomListService = syncService.roomListService()
-let handle = try await roomListService.allRooms().entries(listener: listener)
+let handle = try await roomListService.allRooms().entriesWithDynamicAdapters(pageSize: 100, listener: listener)
 
 // Start the sync loop.
 await syncService.start()

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -23,7 +23,7 @@ let client = try await ClientBuilder()
     .serverNameOrHomeserverUrl(serverNameOrUrl: "matrix.org")
     .sessionPaths(dataPath: URL.applicationSupportDirectory.path(percentEncoded: false),
                   cachePath: URL.cachesDirectory.path(percentEncoded: false))
-    .slidingSyncVersionBuilder(versionBuilder: .discoverProxy)
+    .slidingSyncVersionBuilder(versionBuilder: .discoverNative)
     .build()
 
 // Login using password authentication.


### PR DESCRIPTION
When trying to get started using this SDK I ran into some issues. After investigating a little it turned out, that the Tutorial provided in "Getting Started.md" still referenced using Sliding Sync through a proxy (as `.discoverProxy`) which was [deprecated on matrix.org in November of 2024](https://matrix.org/blog/2024/11/14/moving-to-native-sliding-sync/).

The described change and a syntax change are addressed in this pull request. I not tested the code to load a timeline or send a message, they might have changed as well.