### PR TITLE
Pin the release macOS deployment target

### DIFF
--- a/Tools/Release/Sources/Release.swift
+++ b/Tools/Release/Sources/Release.swift
@@ -55,7 +55,10 @@ struct Release: AsyncParsableCommand {
         Log.info("Building \(branch) at \(commitHash)")
         
         // unset fixes an issue where swift compilation prevents building for targets other than macOS
-        try Zsh.run(command: "unset SDKROOT && cargo xtask swift build-framework --release", directory: buildDirectory)
+        try Zsh.run(
+            command: "unset SDKROOT && cargo xtask swift build-framework --release --macos-deployment-target=12.0",
+            directory: buildDirectory
+        )
         
         return BuildProduct(sourceRepo: sourceRepo,
                             version: version,


### PR DESCRIPTION
## Summary

Build release XCFrameworks with an explicit macOS 12.0 deployment target, matching the Swift package manifest's declared minimum.

Without this argument, Rust/C archive members inherit the release builder's current macOS version. Published releases `26.05.13` and `26.06.06` consequently produce hundreds of deployment-target mismatch warnings when linked by supported macOS consumers.

Tracks #30.

## Dependency

Must merge after matrix-org/matrix-rust-sdk#6751, which adds the `--macos-deployment-target` xtask option consumed here. Both PRs are ready for review.

## Verification

- RED source contract confirmed that the release invocation omitted a macOS deployment target.
- GREEN source contract confirms `--macos-deployment-target=12.0` is present.
- `swift build --package-path Tools/Release` passes.
- An optimized local Matrix Rust SDK release build with the paired option assembled the full macOS XCFramework. Its representative Rust/C/assembly archive members report `minos 12.0`.
- A clean macOS 13 SwiftPM consumer linked the generated release XCFramework with zero deployment-target mismatch warnings and zero oversized `__eh_frame` warnings; focused tests, release app packaging, deep code-sign verification, and launch smoke passed.